### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Open [http://localhost:9966/](http://localhost:9966/) and start changing exercis
 
 ## Color Pickers
 
-- [Google HSL Color Picker](https://g.co/kgs/xoe6Sv)
+- [Google HSV Color Picker](https://g.co/kgs/xoe6Sv)
 - [OKLCH and LCH Color Picker](https://oklch.com/)
 - [OKHSV and OKHSL Color Picker](https://ok-color-picker.netlify.app/) (related [blog post](https://bottosson.github.io/posts/colorpicker/))
 - [HSLuv](https://www.hsluv.org)


### PR DESCRIPTION
The google color picker is falsely labelled as a HSL picker. Its a HSV.
If it was HSL it would be all white on top:
![image](https://github.com/mattdesl/workshop-generative-color/assets/608386/a642406c-8a08-4933-aa56-edcaf6aa8773)
